### PR TITLE
The aud validation to brought in line with the specs

### DIFF
--- a/src/OpenIDConnectProvider.php
+++ b/src/OpenIDConnectProvider.php
@@ -12,6 +12,7 @@ use League\OAuth2\Client\Provider\GenericProvider;
 use InvalidArgumentException;
 use OpenIDConnectClient\Exception\InvalidTokenException;
 use OpenIDConnectClient\Validator\EqualsTo;
+use OpenIDConnectClient\Validator\EqualsToOrContains;
 use OpenIDConnectClient\Validator\GreaterOrEqualsTo;
 use OpenIDConnectClient\Validator\LesserOrEqualsTo;
 use OpenIDConnectClient\Validator\NotEmpty;
@@ -57,7 +58,7 @@ class OpenIDConnectProvider extends GenericProvider
             new NotEmpty('iat', true),
             new GreaterOrEqualsTo('exp', true),
             new EqualsTo('iss', true),
-            new EqualsTo('aud', true),
+            new EqualsToOrContains('aud', true),
             new NotEmpty('sub', true),
             new LesserOrEqualsTo('nbf'),
             new EqualsTo('jti'),

--- a/src/OpenIDConnectProvider.php
+++ b/src/OpenIDConnectProvider.php
@@ -154,7 +154,7 @@ class OpenIDConnectProvider extends GenericProvider
             'auth_time' => $currentTime,
             'iat'       => $currentTime,
             'nbf'       => $currentTime,
-            'aud'       => [$this->clientId]
+            'aud'       => $this->clientId
         ];
 
         // If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.

--- a/src/Validator/EqualsToOrContains.php
+++ b/src/Validator/EqualsToOrContains.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author automatix
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace OpenIDConnectClient\Validator;
+
+
+class EqualsToOrContains implements ValidatorInterface
+{
+    use ValidatorTrait;
+
+    public function isValid($expectedValue, $actualValue)
+    {
+        $valid = false;
+        if (! is_array($actualValue)) {
+            $valid = $expectedValue === $actualValue;
+            if (! $valid) {
+                $this->message = sprintf("%s is invalid as it does not equal expected %s", $actualValue, $expectedValue);
+            }
+        } else {
+            $valid = in_array($expectedValue, $actualValue);
+            if (! $valid) {
+                $this->message = sprintf("The value is invalid as the given array does not contain expected %s", $expectedValue);
+            }
+        }
+
+        return $valid;
+    }
+}


### PR DESCRIPTION
The ID Token's `aud` value `MAY` be an array:

[JSON Web Token (JWT) `->` 4.1.3. "aud" (Audience) Claim](https://tools.ietf.org/html/rfc7519#section-4.1.3):

> "In the general case, the "aud" value is an array of case-sensitive strings, each containing a StringOrURI value."

[OpenID Connect Core 1.0 `->` 3.1.3.7. ID Token Validation](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation)

> "Clients MUST validate the ID Token in the Token Response in the following manner:
[...] 3. [...] The aud (audience) Claim MAY contain an array with more than one element."

Now the library can process both -- string and array -- as input value for the `aud`.