### PR TITLE
Upgrade to lcobucci/jwt 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This package uses the PHP League's [OAuth2 Client](https://github.com/thephpleag
 The following versions of PHP are supported.
 
 * PHP 7.4
-* PHP 8.0 (coming soon, needs use `lcobucci\jwt:v4.1`)
+* PHP 8.0
+* PHP 8.1
 
 ## Usage
 You may test your OpenID Connect Client against [bshaffer's demo oauth2 server](https://github.com/bshaffer/oauth2-demo-php).

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "lcobucci/jwt": "^4.1",
+        "lcobucci/jwt": "~4.0",
         "league/oauth2-client": "^2.0",
         "webmozart/assert": "^1.10"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "lcobucci/jwt": "^3.4",
+        "lcobucci/jwt": "^4.1",
         "league/oauth2-client": "^2.0",
         "webmozart/assert": "^1.10"
     },
@@ -24,6 +24,11 @@
         "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.6"
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "433689a61bcbd9734f875e4f8bf3a6e8",
+    "content-hash": "7ce2b42aa5cdceefead923e21b2e3d03",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11bcfe434106185c14073b925fcc9469",
+    "content-hash": "433689a61bcbd9734f875e4f8bf3a6e8",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -330,69 +330,53 @@
             "time": "2021-10-06T17:43:30+00:00"
         },
         {
-            "name": "lcobucci/jwt",
-            "version": "3.4.6",
+            "name": "lcobucci/clock",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "3ef8657a78278dfeae7707d51747251db4176240"
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "fb533e093fd61321bfcbac08b131ce805fe183d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/3ef8657a78278dfeae7707d51747251db4176240",
-                "reference": "3ef8657a78278dfeae7707d51747251db4176240",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/fb533e093fd61321bfcbac08b131ce805fe183d3",
+                "reference": "fb533e093fd61321bfcbac08b131ce805fe183d3",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "ext-openssl": "*",
-                "php": "^5.6 || ^7.0"
+                "php": "^8.0",
+                "stella-maris/clock": "^0.1.4"
             },
             "require-dev": {
-                "mikey179/vfsstream": "~1.5",
-                "phpmd/phpmd": "~2.2",
-                "phpunit/php-invoker": "~1.1",
-                "phpunit/phpunit": "^5.7 || ^7.3",
-                "squizlabs/php_codesniffer": "~2.3"
-            },
-            "suggest": {
-                "lcobucci/clock": "*"
+                "infection/infection": "^0.26",
+                "lcobucci/coding-standard": "^8.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Lcobucci\\JWT\\": "src"
-                },
-                "files": [
-                    "compat/class-aliases.php",
-                    "compat/json-exception-polyfill.php",
-                    "compat/lcobucci-clock-polyfill.php"
-                ]
+                    "Lcobucci\\Clock\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Luís Otávio Cobucci Oblonczyk",
-                    "email": "lcobucci@gmail.com",
-                    "role": "Developer"
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
                 }
             ],
-            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
-            "keywords": [
-                "JWS",
-                "jwt"
-            ],
+            "description": "Yet another clock abstraction",
             "support": {
-                "issues": "https://github.com/lcobucci/jwt/issues",
-                "source": "https://github.com/lcobucci/jwt/tree/3.4.6"
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/2.2.0"
             },
             "funding": [
                 {
@@ -404,7 +388,81 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-09-28T19:18:28+00:00"
+            "time": "2022-04-19T19:34:17+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "4.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "fe2d89f2eaa7087af4aa166c6f480ef04e000582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/fe2d89f2eaa7087af4aa166c6f480ef04e000582",
+                "reference": "fe2d89f2eaa7087af4aa166c6f480ef04e000582",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "lcobucci/clock": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.21",
+                "lcobucci/coding-standard": "^6.0",
+                "mikey179/vfsstream": "^1.6.7",
+                "phpbench/phpbench": "^1.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/php-invoker": "^3.1",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/4.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-09-28T19:34:56+00:00"
         },
         {
             "name": "league/oauth2-client",
@@ -729,6 +787,53 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "stella-maris/clock",
+            "version": "0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/stella-maris/clock.git",
+                "reference": "8a0a967896df4c63417385dc69328a0aec84d9cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=8a0a967896df4c63417385dc69328a0aec84d9cf",
+                "reference": "8a0a967896df4c63417385dc69328a0aec84d9cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StellaMaris\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Heigl",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
+            "homepage": "https://gitlab.com/stella-maris/clock",
+            "keywords": [
+                "clock",
+                "datetime",
+                "point in time",
+                "psr20"
+            ],
+            "support": {
+                "issues": "https://gitlab.com/stella-maris/clock/-/issues",
+                "source": "https://gitlab.com/stella-maris/clock/-/tree/0.1.4"
+            },
+            "time": "2022-04-17T14:12:26+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5043,5 +5148,5 @@
         "php": ">= 7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -5,27 +5,35 @@ declare(strict_types=1);
 namespace OpenIDConnectClient;
 
 use Lcobucci\JWT\Configuration;
-use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\Plain;
 use League\OAuth2\Client\Token\AccessToken as LeagueAccessToken;
+use OpenIDConnectClient\Exception\InvalidTokenException;
 
 final class AccessToken extends LeagueAccessToken
 {
-    private Token $idToken;
+    private ?Plain $idToken;
 
     public function __construct(array $options = [])
     {
         parent::__construct($options);
+        $this->idToken = null;
 
         if (isset($this->values['id_token'])) {
             // Signature is validated outside, this just parses the token
-            $this->idToken = Configuration::forUnsecuredSigner()
+            $token = Configuration::forUnsecuredSigner()
                 ->parser()
                 ->parse($this->values['id_token']);
+
+            if (!$token instanceof Plain) {
+                throw new InvalidTokenException('Received wrong token type (expected Plain)');
+            }
+            $this->idToken = $token;
+
             unset($this->values['id_token']);
         }
     }
 
-    public function getIdToken(): ?Token
+    public function getIdToken(): ?Plain
     {
         return $this->idToken ?? null;
     }

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenIDConnectClient;
 
-use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Token;
 use League\OAuth2\Client\Token\AccessToken as LeagueAccessToken;
 
@@ -17,7 +17,10 @@ final class AccessToken extends LeagueAccessToken
         parent::__construct($options);
 
         if (isset($this->values['id_token'])) {
-            $this->idToken = (new Parser())->parse($this->values['id_token']);
+            // Signature is validated outside, this just parses the token
+            $this->idToken = Configuration::forUnsecuredSigner()
+                ->parser()
+                ->parse($this->values['id_token']);
             unset($this->values['id_token']);
         }
     }

--- a/src/OpenIDConnectProvider.php
+++ b/src/OpenIDConnectProvider.php
@@ -123,6 +123,10 @@ final class OpenIDConnectProvider extends GenericProvider
     public function getAccessToken($grant, array $options = [])
     {
         $accessToken = parent::getAccessToken($grant, $options);
+        if (!$accessToken instanceof AccessToken) {
+            throw new InvalidTokenException('Received wrong access token type');
+        }
+
         $token = $accessToken->getIdToken();
 
         // id_token is empty.

--- a/src/Validator/ValidatorChain.php
+++ b/src/Validator/ValidatorChain.php
@@ -55,7 +55,14 @@ final class ValidatorChain
                 continue;
             }
 
-            if (!$validator->isValid($data[$claim], $claims->get($claim))) {
+            // All timestamps will be converted to DateTimeImmutable
+            // Convert them back to unix timestamp here so we can compare as numbers
+            $claimValue = $claims->get($claim);
+            if ($claimValue instanceof \DateTimeInterface) {
+                $claimValue = $claimValue->getTimestamp();
+            }
+
+            if (!$validator->isValid($data[$claim], $claimValue)) {
                 $valid = false;
                 $this->messages[$claim] = $validator->getMessage();
             }

--- a/src/Validator/ValidatorChain.php
+++ b/src/Validator/ValidatorChain.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenIDConnectClient\Validator;
 
-use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\Plain;
 use OpenIDConnectClient\Exception\UnknownValidatorRequestedException;
 use Webmozart\Assert\Assert;
 
@@ -39,7 +39,7 @@ final class ValidatorChain
         return $this;
     }
 
-    public function validate(array $data, Token $token): bool
+    public function validate(array $data, Plain $token): bool
     {
         $valid = true;
         $claims = $token->claims();

--- a/tests/Unit/OpenIDConnectProviderTest.php
+++ b/tests/Unit/OpenIDConnectProviderTest.php
@@ -170,7 +170,7 @@ final class OpenIDConnectProviderTest extends TestCase
         // OpenIDConnectProvider::getAccessToken
         $this->signer
             ->expects(self::once())
-            ->method('getAlgorithmId')
+            ->method('algorithmId')
             ->willReturn('HS256');
 
         $this->signer
@@ -222,7 +222,7 @@ final class OpenIDConnectProviderTest extends TestCase
         // OpenIDConnectProvider::getAccessToken
         $this->signer
             ->expects(self::exactly(2))
-            ->method('getAlgorithmId')
+            ->method('algorithmId')
             ->willReturn('HS256');
 
         $this->signer
@@ -253,7 +253,7 @@ final class OpenIDConnectProviderTest extends TestCase
         // OpenIDConnectProvider::getAccessToken
         $this->signer
             ->expects(self::once())
-            ->method('getAlgorithmId')
+            ->method('algorithmId')
             ->willReturn('HS256');
 
         $this->signer

--- a/tests/Unit/Validator/ValidatorChainTest.php
+++ b/tests/Unit/Validator/ValidatorChainTest.php
@@ -7,6 +7,7 @@ namespace OpenIDConnectClient\Tests\Unit\Validator;
 use InvalidArgumentException;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Token\DataSet;
+use Lcobucci\JWT\Token\Plain;
 use OpenIDConnectClient\Validator\ValidatorChain;
 use OpenIDConnectClient\Validator\ValidatorInterface;
 use PHPUnit\Framework\TestCase;
@@ -128,7 +129,7 @@ final class ValidatorChainTest extends TestCase
         $this->chain->addValidator($firstValidator);
         $this->chain->addValidator($secondValidator);
 
-        $token = $this->createMock(Token::class);
+        $token = $this->createMock(Plain::class);
         $claims = $this->createMock(DataSet::class);
         $token
             ->expects(self::once())
@@ -230,7 +231,7 @@ final class ValidatorChainTest extends TestCase
         $this->chain->addValidator($thirdValidator);
         $this->chain->addValidator($fourthValidator);
 
-        $token = $this->createMock(Token::class);
+        $token = $this->createMock(Plain::class);
         $claims = $this->createMock(DataSet::class);
         $token
             ->expects(self::once())


### PR DESCRIPTION
This PR upgrades lcobucci/jwt to v4 with all the necessary changes.

This was needed for my project where I use lcobucci/jwt v4 and PHP 8.1. I think it's safe to say this fixes #28.
I got all the unit tests to pass and there don't seem to be any breaking changes expect for some return type changes.